### PR TITLE
Replace sysbench with stress and more

### DIFF
--- a/stability_test.sh
+++ b/stability_test.sh
@@ -13,44 +13,56 @@ echo "$(tput setaf 2)
  ~ (   ) (   ) ~
 ( : '~'.~.'~' : )
  ~ .~ (   ) ~. ~
-  (  : '~' :  ) $(tput sgr0) Stability Test$(tput setaf 1)
+  (  : '~' :  ) $(tput sgr0) Stability Test $(tput setaf 1)
    '~ .~~~. ~'
        '~'
 $(tput sgr0)" 
+ 
 
-#show CPU frequency and temperature function:
+# show CPU frequency and temperature function:
 temp_freq () {
-    cat /sys/devices/system/system/cpu/cpu0/cpufreq/scaling_cur_freq
-    vcgencmd measure_temp
+    local FREQ=$(cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_cur_freq) # measure current CPU frequency on raspberry pi
+    local TEMP=$(vcgencmd measure_temp | tail -c 7) # measure current temperature on raspberry pi
+    echo "The CPU frequency is $(($FREQ / 1000))mhz"
+    echo "The CPU temperature is $TEMP"
 }
 
+# stress test function:
 stress_test () {
-    #set variable to number of cores the system has
-    local CORES=nproc
-    #sysbench test, runs pi at full tilt for long enough to reach max temp
-    sysbench --test=cpu --cpu-max-prime=50000 --num-threads=$CORES run >/dev/null 2>&1
+    local TIME=250 # how long the stress test runs for
+    local CORES=$(nproc) # determine Raspberry Pi model
+    # show CPU frequency and temperature before running at full load:
+    temp_freq
+    # stress test, should make pi reach max temp if ran long enough:
+    echo "Running stress and GLXgears for $TIME seconds"
+    if [ $CORES == 4 ]
+    then
+        echo "Running stress test for Raspberry Pi 2 or 3"
+    else
+        echo "Running stress test for Raspberry Pi 1 or Zero"
+    fi
+    stress --cpu $CORES --timeout $TIME > /dev/null &
+    # glxgears to put load on GPU too
+    glxgears > /dev/null & sleep $TIME ; kill $!
+    # show CPU frequency and temperature after running at full load:
+    temp_freq
 }
 
-# Menu 
 PS3='Please enter your choice: '
 options=("Stress Test" "Show temperature" "Quit")
 select opt in "${options[@]}"
 do
     case $opt in
         "Stress Test")
-            echo "Running sysbench"
-            #show CPU frequency and temperature before running at full load:
-            temp_freq
+            # run the stress test
             stress_test
-            #show CPU frequency and temperature after running at full load:
-            temp_freq
             ;;
         "Show temperature")
-            echo ""
-            #show CPU frequency and temperature
+            # show CPU frequency and temperature
             temp_freq
             ;;
         "Quit")
+            # quit the program
             break
             ;;
         *) echo invalid option;;


### PR DESCRIPTION
Replace sysbench with stress
Add TIME variable that determines how long the test runs for
Move printing temperature and frequency into stress_test function 
Add if running on raspberry pi 2/3 or 1/Zero
Tail temperature output to neaten terminal output
Divide Frequency output by 1000 to make terminal output in mhz
Add comments
